### PR TITLE
Enable `async with AsyncClient(..) as client` construct

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ client = async_hvac.AsyncClient(url='https://localhost:8200',
 client = async_hvac.AsyncClient(url='https://localhost:8200', verify=False)
 ```
 
+Note that you will have to close the client with `client.close()` in order to
+avoid lingering open aiohttp.client.ClientSession's. An alternative is to open
+the client in a `with`-statement:
+
+```python
+async with async_hvac.AsyncClient(url='https://localhost:8200') as client:
+    print(await client.read('secret/foo'))
+```
+
 ### Read and write to secret backends
 
 ```python

--- a/async_hvac/tests/test_client.py
+++ b/async_hvac/tests/test_client.py
@@ -1,9 +1,7 @@
-from asynctest import TestCase
-
-from parameterized import parameterized
-
 from async_hvac import AsyncClient
 from async_hvac.tests.util import RequestsMocker
+from asynctest import TestCase
+from parameterized import parameterized
 
 
 class TestClient(TestCase):
@@ -31,3 +29,25 @@ class TestClient(TestCase):
             second=response.status,
         )
         await client.close()
+
+    @parameterized.expand([
+        ("standard Vault address", 'https://localhost:8200'),
+        ("Vault address with route", 'https://example.com/vault'),
+    ])
+    @RequestsMocker()
+    async def test_async_with_request(self, test_label, test_url, requests_mocker):
+        test_path = 'v1/sys/health'
+        expected_status_code = 200
+        mock_url = '{0}/{1}'.format(test_url, test_path)
+        requests_mocker.register_uri(
+            method='GET',
+            url=mock_url,
+        )
+        async with AsyncClient(url=test_url) as client:
+            response = await client._get(
+                url='v1/sys/health',
+            )
+            self.assertEqual(
+                first=expected_status_code,
+                second=response.status,
+            )

--- a/async_hvac/v1/__init__.py
+++ b/async_hvac/v1/__init__.py
@@ -4,16 +4,16 @@ import json
 import ssl
 from base64 import b64encode
 
+import aiohttp
+from async_hvac import aws_utils, exceptions
+
 try:
     import hcl
 
     has_hcl_parser = True
 except ImportError:
     has_hcl_parser = False
-import aiohttp
 
-from async_hvac import aws_utils
-from async_hvac import exceptions
 
 
 class AsyncClient(object):
@@ -36,6 +36,19 @@ class AsyncClient(object):
             self._sslcontext.load_cert_chain(self._cert[0], self._cert[1])
         else:
             self._sslcontext = False
+
+    def __enter__(self):
+        raise TypeError("Use async with instead")
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        # __exit__ should exist in pair with __enter__ but never executed
+        pass  # pragma: no cover
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        await self.close()
 
     @property
     def session(self):

--- a/async_hvac/v1/__init__.py
+++ b/async_hvac/v1/__init__.py
@@ -15,7 +15,6 @@ except ImportError:
     has_hcl_parser = False
 
 
-
 class AsyncClient(object):
     def __init__(self, url='http://127.0.0.1:8200', token=None,
                  cert=None, verify=True, timeout=30, proxies=None,


### PR DESCRIPTION
I forgot to  add `client.close()`s, and got a lot of
```
Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x1108eb320>
Unclosed connector
connections: ['[(<aiohttp.client_proto.ResponseHandler object at 0x110a5de48>, 41227.915917165)]']
connector: <aiohttp.connector.TCPConnector object at 0x1108eb358>
```

Adding `client.close()` everywhere works, but I think it's more elegant this way :).