### PR TITLE
Make aiohttp requirement not so strict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-aiohttp==3.7.4
+aiohttp>=3.3.1
 pyhcl==0.3.10

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     classifiers=['License :: OSI Approved :: Apache Software License'],
     packages=find_packages(),
     install_requires=[
-        'aiohttp==3.7.4',
+        'aiohttp>=3.3.1',
     ],
     include_package_data=True,
     package_data={'async_hvac': ['version']},


### PR DESCRIPTION
Its impossible to use async-hvac with higher versions of aiohttp than one freezed in setup.py